### PR TITLE
:sparkles:Feat: 댓글 목록/카운트 Redis 캐시 적용

### DIFF
--- a/src/main/java/com/be/sportizebe/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/be/sportizebe/domain/comment/controller/CommentController.java
@@ -1,6 +1,7 @@
 package com.be.sportizebe.domain.comment.controller;
 
 import com.be.sportizebe.domain.comment.dto.request.CreateCommentRequest;
+import com.be.sportizebe.domain.comment.dto.response.CommentListResponse;
 import com.be.sportizebe.domain.comment.dto.response.CommentResponse;
 import com.be.sportizebe.domain.comment.service.CommentService;
 import com.be.sportizebe.domain.user.entity.User;
@@ -38,10 +39,10 @@ public class CommentController {
 
     @GetMapping
     @Operation(summary = "댓글 목록 조회", description = "게시글의 댓글 목록 조회 (대댓글 포함)")
-    public ResponseEntity<BaseResponse<List<CommentResponse>>> getComments(
+    public ResponseEntity<BaseResponse<CommentListResponse>> getComments(
         @Parameter(description = "게시글 ID") @PathVariable Long postId) {
-        List<CommentResponse> responses = commentService.getCommentsByPostId(postId);
-        return ResponseEntity.ok(BaseResponse.success(responses));
+        CommentListResponse response = commentService.getCommentsByPostId(postId);
+        return ResponseEntity.ok(BaseResponse.success(response));
     }
 
     @DeleteMapping("/{commentId}")
@@ -50,7 +51,7 @@ public class CommentController {
         @Parameter(description = "게시글 ID") @PathVariable Long postId,
         @Parameter(description = "댓글 ID") @PathVariable Long commentId,
         @AuthenticationPrincipal User user) {
-        commentService.deleteComment(commentId, user);
+        commentService.deleteComment(postId, commentId, user);
         return ResponseEntity.ok(BaseResponse.success("댓글 삭제 성공", null));
     }
 

--- a/src/main/java/com/be/sportizebe/domain/comment/dto/response/CommentListResponse.java
+++ b/src/main/java/com/be/sportizebe/domain/comment/dto/response/CommentListResponse.java
@@ -1,0 +1,11 @@
+package com.be.sportizebe.domain.comment.dto.response;
+
+import java.util.List;
+
+public record CommentListResponse(
+        List<CommentResponse> comments
+) {
+    public static CommentListResponse of(List<CommentResponse> comments) {
+        return new CommentListResponse(comments);
+    }
+}

--- a/src/main/java/com/be/sportizebe/domain/comment/service/CommentService.java
+++ b/src/main/java/com/be/sportizebe/domain/comment/service/CommentService.java
@@ -1,6 +1,7 @@
 package com.be.sportizebe.domain.comment.service;
 
 import com.be.sportizebe.domain.comment.dto.request.CreateCommentRequest;
+import com.be.sportizebe.domain.comment.dto.response.CommentListResponse;
 import com.be.sportizebe.domain.comment.dto.response.CommentResponse;
 import com.be.sportizebe.domain.user.entity.User;
 
@@ -12,10 +13,10 @@ public interface CommentService {
   CommentResponse createComment(Long postId, CreateCommentRequest request, User user);
 
   // 게시글의 댓글 목록 조회
-  List<CommentResponse> getCommentsByPostId(Long postId);
+  CommentListResponse getCommentsByPostId(Long postId);
 
   // 댓글 삭제
-  void deleteComment(Long commentId, User user);
+  void deleteComment(Long postId, Long commentId, User user);
 
   // 게시글의 댓글 수 조회
   long getCommentCount(Long postId);


### PR DESCRIPTION
## #️⃣ Issue Number
- closed #
<!--- ex) #이슈번호 -->

## 📝 요약(Summary)

댓글 도메인에 Redis 캐시를 적용하기 위해 응답 구조와 서비스 시그니처를 정리했습니다.

- 댓글 목록 조회 응답을 `List` → `CommentListResponse`로 래핑하여 캐시 안정성 확보
- 댓글 목록(`commentList`) 및 댓글 수(`commentCount`)에 Redis 캐시 적용
- 댓글 생성/삭제 시 관련 캐시를 함께 무효화하여 데이터 정합성 유지
- `commentList` 캐시에 대해 전용 Serializer 및 TTL 설정 추가

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 코드 리팩토링
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택

## 💬 공유사항 to 리뷰어

- 댓글 목록 캐시는 `List<CommentResponse>` 대신  
  `CommentListResponse`로 래핑하여 **직렬화/역직렬화 타입을 명확히** 했습니다.
- 댓글 생성/삭제 시 `commentList`, `commentCount`를 함께 evict 하여
  캐시 불일치가 발생하지 않도록 처리했습니다.
- `commentCount`는 단순 타입(Long)이므로 별도 CacheConfig 없이 기본 설정을 사용했습니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대해 로컬 테스트를 진행했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **성능 개선**
  * 댓글 목록 조회 성능을 향상시키기 위해 캐싱을 추가했습니다.
  * 댓글 관련 작업(생성, 삭제, 조회, 개수 확인)에 캐싱을 적용하여 응답 속도가 개선됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->