### PR TITLE
♻️ Refactor: JwtAuthenticationFilter User 조회 Redis 캐싱 적용

### DIFF
--- a/src/main/java/com/be/sportizebe/domain/chat/controller/NoteController.java
+++ b/src/main/java/com/be/sportizebe/domain/chat/controller/NoteController.java
@@ -6,9 +6,9 @@ import com.be.sportizebe.domain.chat.service.ChatRoomService;
 import com.be.sportizebe.domain.post.entity.Post;
 import com.be.sportizebe.domain.post.exception.PostErrorCode;
 import com.be.sportizebe.domain.post.repository.PostRepository;
-import com.be.sportizebe.domain.user.entity.User;
 import com.be.sportizebe.global.exception.CustomException;
 import com.be.sportizebe.global.response.BaseResponse;
+import com.be.sportizebe.global.cache.dto.UserAuthInfo;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -33,12 +33,12 @@ public class NoteController {
     @Operation(summary = "1대1 채팅방 생성", description = "게시글 작성자와 1대1 쪽지 채팅방을 생성합니다. 채팅방 이름은 게시글 제목으로 설정됩니다. 이미 채팅방이 존재하면 기존 채팅방을 반환합니다.")
     public ResponseEntity<BaseResponse<ChatRoomResponse>> createChatRoom(
             @Parameter(description = "게시글 ID") @PathVariable Long postId,
-            @AuthenticationPrincipal User user) {
+            @AuthenticationPrincipal UserAuthInfo userAuthInfo) {
 
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new CustomException(PostErrorCode.POST_NOT_FOUND));
 
-        ChatRoom room = chatRoomService.createNote(post, user);
+        ChatRoom room = chatRoomService.createNote(post, userAuthInfo.getId());
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(BaseResponse.success("채팅방 생성 성공", ChatRoomResponse.from(room)));
@@ -47,9 +47,9 @@ public class NoteController {
     @GetMapping("/rooms")
     @Operation(summary = "내 쪽지 채팅방 목록 조회", description = "현재 사용자가 참여한 모든 쪽지 채팅방 목록을 조회합니다.")
     public ResponseEntity<BaseResponse<List<ChatRoomResponse>>> getMyChatRooms(
-            @AuthenticationPrincipal User user) {
+            @AuthenticationPrincipal UserAuthInfo userAuthInfo) {
 
-        List<ChatRoomResponse> rooms = chatRoomService.findMyNoteRooms(user).stream()
+        List<ChatRoomResponse> rooms = chatRoomService.findMyNoteRooms(userAuthInfo.getId()).stream()
                 .map(ChatRoomResponse::from)
                 .toList();
 

--- a/src/main/java/com/be/sportizebe/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/be/sportizebe/domain/chat/repository/ChatRoomRepository.java
@@ -2,7 +2,6 @@ package com.be.sportizebe.domain.chat.repository;
 
 import com.be.sportizebe.domain.chat.entity.ChatRoom;
 import com.be.sportizebe.domain.post.entity.Post;
-import com.be.sportizebe.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -11,8 +10,8 @@ import java.util.Optional;
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
     // 특정 게시글에 대해 두 사용자 간의 1대1 채팅방이 이미 존재하는지 확인
-    Optional<ChatRoom> findByPostAndGuestUser(Post post, User guestUser);
+    Optional<ChatRoom> findByPostAndGuestUserId(Post post, Long guestUserId);
 
     // 사용자가 참여한 1대1 채팅방 목록 조회 (게시글 작성자 또는 채팅 요청자로 참여)
-    List<ChatRoom> findByPost_UserOrGuestUser(User postUser, User guestUser);
+    List<ChatRoom> findByPost_UserIdOrGuestUserId(Long postUserId, Long guestUserId);
 }

--- a/src/main/java/com/be/sportizebe/domain/club/controller/ClubController.java
+++ b/src/main/java/com/be/sportizebe/domain/club/controller/ClubController.java
@@ -5,8 +5,8 @@ import com.be.sportizebe.domain.club.dto.request.ClubUpdateRequest;
 import com.be.sportizebe.domain.club.dto.response.ClubImageResponse;
 import com.be.sportizebe.domain.club.dto.response.ClubResponse;
 import com.be.sportizebe.domain.club.service.ClubServiceImpl;
-import com.be.sportizebe.domain.user.entity.User;
 import com.be.sportizebe.global.response.BaseResponse;
+import com.be.sportizebe.global.cache.dto.UserAuthInfo;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -32,8 +32,8 @@ public class ClubController {
   public ResponseEntity<BaseResponse<ClubResponse>> createClub(
       @RequestPart("request") @Valid ClubCreateRequest request,
       @RequestPart(value = "image", required = false) MultipartFile image,
-      @AuthenticationPrincipal User user) {
-    ClubResponse response = clubService.createClub(request, image, user);
+      @AuthenticationPrincipal UserAuthInfo userAuthInfo) {
+    ClubResponse response = clubService.createClub(request, image, userAuthInfo.getId());
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(BaseResponse.success("동호회 생성 성공", response));
   }
@@ -43,8 +43,8 @@ public class ClubController {
   public ResponseEntity<BaseResponse<ClubResponse>> updateClub(
       @PathVariable Long clubId,
       @RequestBody @Valid ClubUpdateRequest request,
-      @AuthenticationPrincipal User user) {
-    ClubResponse response = clubService.updateClub(clubId, request, user);
+      @AuthenticationPrincipal UserAuthInfo userAuthInfo) {
+    ClubResponse response = clubService.updateClub(clubId, request, userAuthInfo.getId());
     return ResponseEntity.ok(BaseResponse.success("동호회 수정 성공", response));
   }
 
@@ -53,8 +53,8 @@ public class ClubController {
   public ResponseEntity<BaseResponse<ClubImageResponse>> updateClubImage(
       @Parameter(description = "동호회 ID") @PathVariable Long clubId,
       @RequestPart("image") MultipartFile image,
-      @AuthenticationPrincipal User user) {
-    ClubImageResponse response = clubService.updateClubImage(clubId, image, user);
+      @AuthenticationPrincipal UserAuthInfo userAuthInfo) {
+    ClubImageResponse response = clubService.updateClubImage(clubId, image, userAuthInfo.getId());
     return ResponseEntity.ok(BaseResponse.success("동호회 사진 수정 성공", response));
   }
 }

--- a/src/main/java/com/be/sportizebe/domain/club/service/ClubService.java
+++ b/src/main/java/com/be/sportizebe/domain/club/service/ClubService.java
@@ -4,13 +4,12 @@ import com.be.sportizebe.domain.club.dto.request.ClubCreateRequest;
 import com.be.sportizebe.domain.club.dto.request.ClubUpdateRequest;
 import com.be.sportizebe.domain.club.dto.response.ClubImageResponse;
 import com.be.sportizebe.domain.club.dto.response.ClubResponse;
-import com.be.sportizebe.domain.user.entity.User;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface ClubService {
-  ClubResponse createClub(ClubCreateRequest request, MultipartFile image, User user); // 동호회 생성
+  ClubResponse createClub(ClubCreateRequest request, MultipartFile image, Long userId); // 동호회 생성
 
-  ClubResponse updateClub(Long clubId, ClubUpdateRequest request, User user); // 동호회 수정
+  ClubResponse updateClub(Long clubId, ClubUpdateRequest request, Long userId); // 동호회 수정
 
-  ClubImageResponse updateClubImage(Long clubId, MultipartFile image, User user); // 동호회 사진 수정
+  ClubImageResponse updateClubImage(Long clubId, MultipartFile image, Long userId); // 동호회 사진 수정
 }

--- a/src/main/java/com/be/sportizebe/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/be/sportizebe/domain/comment/controller/CommentController.java
@@ -4,8 +4,8 @@ import com.be.sportizebe.domain.comment.dto.request.CreateCommentRequest;
 import com.be.sportizebe.domain.comment.dto.response.CommentListResponse;
 import com.be.sportizebe.domain.comment.dto.response.CommentResponse;
 import com.be.sportizebe.domain.comment.service.CommentService;
-import com.be.sportizebe.domain.user.entity.User;
 import com.be.sportizebe.global.response.BaseResponse;
+import com.be.sportizebe.global.cache.dto.UserAuthInfo;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -15,8 +15,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -31,8 +29,8 @@ public class CommentController {
     public ResponseEntity<BaseResponse<CommentResponse>> createComment(
         @Parameter(description = "게시글 ID") @PathVariable Long postId,
         @RequestBody @Valid CreateCommentRequest request,
-        @AuthenticationPrincipal User user) {
-        CommentResponse response = commentService.createComment(postId, request, user);
+        @AuthenticationPrincipal UserAuthInfo userAuthInfo) {
+        CommentResponse response = commentService.createComment(postId, request, userAuthInfo.getId());
         return ResponseEntity.status(HttpStatus.CREATED)
             .body(BaseResponse.success("댓글 생성 성공", response));
     }
@@ -50,8 +48,8 @@ public class CommentController {
     public ResponseEntity<BaseResponse<Void>> deleteComment(
         @Parameter(description = "게시글 ID") @PathVariable Long postId,
         @Parameter(description = "댓글 ID") @PathVariable Long commentId,
-        @AuthenticationPrincipal User user) {
-        commentService.deleteComment(postId, commentId, user);
+        @AuthenticationPrincipal UserAuthInfo userAuthInfo) {
+        commentService.deleteComment(postId, commentId, userAuthInfo.getId());
         return ResponseEntity.ok(BaseResponse.success("댓글 삭제 성공", null));
     }
 

--- a/src/main/java/com/be/sportizebe/domain/comment/service/CommentService.java
+++ b/src/main/java/com/be/sportizebe/domain/comment/service/CommentService.java
@@ -3,20 +3,17 @@ package com.be.sportizebe.domain.comment.service;
 import com.be.sportizebe.domain.comment.dto.request.CreateCommentRequest;
 import com.be.sportizebe.domain.comment.dto.response.CommentListResponse;
 import com.be.sportizebe.domain.comment.dto.response.CommentResponse;
-import com.be.sportizebe.domain.user.entity.User;
-
-import java.util.List;
 
 public interface CommentService {
 
   // 댓글 생성 (대댓글 포함)
-  CommentResponse createComment(Long postId, CreateCommentRequest request, User user);
+  CommentResponse createComment(Long postId, CreateCommentRequest request, Long userId);
 
   // 게시글의 댓글 목록 조회
   CommentListResponse getCommentsByPostId(Long postId);
 
   // 댓글 삭제
-  void deleteComment(Long postId, Long commentId, User user);
+  void deleteComment(Long postId, Long commentId, Long userId);
 
   // 게시글의 댓글 수 조회
   long getCommentCount(Long postId);

--- a/src/main/java/com/be/sportizebe/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/be/sportizebe/domain/comment/service/CommentServiceImpl.java
@@ -10,6 +10,8 @@ import com.be.sportizebe.domain.post.entity.Post;
 import com.be.sportizebe.domain.post.exception.PostErrorCode;
 import com.be.sportizebe.domain.post.repository.PostRepository;
 import com.be.sportizebe.domain.user.entity.User;
+import com.be.sportizebe.domain.user.exception.UserErrorCode;
+import com.be.sportizebe.domain.user.repository.UserRepository;
 import com.be.sportizebe.global.exception.CustomException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -27,14 +29,19 @@ public class CommentServiceImpl implements CommentService {
 
   private final CommentRepository commentRepository;
   private final PostRepository postRepository;
+  private final UserRepository userRepository;
 
   @Override
   @CacheEvict(cacheNames = {"commentList", "commentCount"}, key = "#postId")
   @Transactional
-  public CommentResponse createComment(Long postId, CreateCommentRequest request, User user) {
+  public CommentResponse createComment(Long postId, CreateCommentRequest request, Long userId) {
     // 게시글 조회
     Post post = postRepository.findById(postId)
         .orElseThrow(() -> new CustomException(PostErrorCode.POST_NOT_FOUND));
+
+    // 사용자 조회
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
 
     // 부모 댓글 조회 (대댓글인 경우)
     Comment parent = null; // null로 초기화
@@ -79,12 +86,12 @@ public class CommentServiceImpl implements CommentService {
   @Override
   @CacheEvict(cacheNames = {"commentList", "commentCount"}, key = "#postId")
   @Transactional
-  public void deleteComment(Long postId, Long commentId, User user) {
+  public void deleteComment(Long postId, Long commentId, Long userId) {
     Comment comment = commentRepository.findById(commentId)
         .orElseThrow(() -> new CustomException(CommentErrorCode.COMMENT_NOT_FOUND));
 
     // 작성자 확인
-    if (comment.getUser().getId() != user.getId()) {
+    if (comment.getUser().getId() != userId) {
       throw new CustomException(CommentErrorCode.COMMENT_DELETE_DENIED);
     }
 

--- a/src/main/java/com/be/sportizebe/domain/like/controller/LikeController.java
+++ b/src/main/java/com/be/sportizebe/domain/like/controller/LikeController.java
@@ -3,8 +3,8 @@ package com.be.sportizebe.domain.like.controller;
 import com.be.sportizebe.domain.like.dto.response.LikeResponse;
 import com.be.sportizebe.domain.like.entity.LikeTargetType;
 import com.be.sportizebe.domain.like.service.LikeService;
-import com.be.sportizebe.domain.user.entity.User;
 import com.be.sportizebe.global.response.BaseResponse;
+import com.be.sportizebe.global.cache.dto.UserAuthInfo;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -24,27 +24,27 @@ public class LikeController {
     @PostMapping("/posts/{postId}")
     @Operation(summary = "게시글 좋아요 토글", description = "게시글 좋아요 추가/취소")
     public ResponseEntity<BaseResponse<LikeResponse>> togglePostLike(
-        @AuthenticationPrincipal User user,
+        @AuthenticationPrincipal UserAuthInfo userAuthInfo,
         @Parameter(description = "게시글 ID") @PathVariable Long postId) {
-        LikeResponse response = likeService.toggleLike(user, LikeTargetType.POST, postId);
+        LikeResponse response = likeService.toggleLike(userAuthInfo.getId(), LikeTargetType.POST, postId);
         return ResponseEntity.ok(BaseResponse.success("좋아요 처리 완료", response));
     }
 
     @PostMapping("/comments/{commentId}")
     @Operation(summary = "댓글 좋아요 토글", description = "댓글 좋아요 추가/취소")
     public ResponseEntity<BaseResponse<LikeResponse>> toggleCommentLike(
-        @AuthenticationPrincipal User user,
+        @AuthenticationPrincipal UserAuthInfo userAuthInfo,
         @Parameter(description = "댓글 ID") @PathVariable Long commentId) {
-        LikeResponse response = likeService.toggleLike(user, LikeTargetType.COMMENT, commentId);
+        LikeResponse response = likeService.toggleLike(userAuthInfo.getId(), LikeTargetType.COMMENT, commentId);
         return ResponseEntity.ok(BaseResponse.success("좋아요 처리 완료", response));
     }
 
     @GetMapping("/posts/{postId}")
     @Operation(summary = "게시글 좋아요 수 조회", description = "게시글의 좋아요 수와 본인 좋아요 여부 조회")
     public ResponseEntity<BaseResponse<LikeResponse>> getPostLikeStatus(
-        @AuthenticationPrincipal User user,
+        @AuthenticationPrincipal UserAuthInfo userAuthInfo,
         @Parameter(description = "게시글 ID") @PathVariable Long postId) {
-        boolean liked = likeService.isLiked(user, LikeTargetType.POST, postId);
+        boolean liked = likeService.isLiked(userAuthInfo.getId(), LikeTargetType.POST, postId);
         long likeCount = likeService.getLikeCount(LikeTargetType.POST, postId);
         LikeResponse response = LikeResponse.of(liked, LikeTargetType.POST, postId, likeCount);
         return ResponseEntity.ok(BaseResponse.success(response));
@@ -53,9 +53,9 @@ public class LikeController {
     @GetMapping("/comments/{commentId}")
     @Operation(summary = "댓글 좋아요 수 조회", description = "댓글의 좋아요 수와 본인 좋아요 여부 조회")
     public ResponseEntity<BaseResponse<LikeResponse>> getCommentLikeStatus(
-        @AuthenticationPrincipal User user,
+        @AuthenticationPrincipal UserAuthInfo userAuthInfo,
         @Parameter(description = "댓글 ID") @PathVariable Long commentId) {
-        boolean liked = likeService.isLiked(user, LikeTargetType.COMMENT, commentId);
+        boolean liked = likeService.isLiked(userAuthInfo.getId(), LikeTargetType.COMMENT, commentId);
         long likeCount = likeService.getLikeCount(LikeTargetType.COMMENT, commentId);
         LikeResponse response = LikeResponse.of(liked, LikeTargetType.COMMENT, commentId, likeCount);
         return ResponseEntity.ok(BaseResponse.success(response));

--- a/src/main/java/com/be/sportizebe/domain/like/repository/LikeRepository.java
+++ b/src/main/java/com/be/sportizebe/domain/like/repository/LikeRepository.java
@@ -2,7 +2,6 @@ package com.be.sportizebe.domain.like.repository;
 
 import com.be.sportizebe.domain.like.entity.Like;
 import com.be.sportizebe.domain.like.entity.LikeTargetType;
-import com.be.sportizebe.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -10,15 +9,14 @@ import java.util.Optional;
 public interface LikeRepository extends JpaRepository<Like, Long> {
 
     // 특정 사용자가 특정 대상에 좋아요 했는지 확인
-    // npe를 방지하기 위해 Optional로 null이 올 수 있는 값을 감쌈(참조시 npe 발생x)
-    Optional<Like> findByUserAndTargetTypeAndTargetId(User user, LikeTargetType targetType, Long targetId);
+    Optional<Like> findByUserIdAndTargetTypeAndTargetId(Long userId, LikeTargetType targetType, Long targetId);
 
     // 특정 사용자가 특정 대상에 좋아요 했는지 여부
-    boolean existsByUserAndTargetTypeAndTargetId(User user, LikeTargetType targetType, Long targetId);
+    boolean existsByUserIdAndTargetTypeAndTargetId(Long userId, LikeTargetType targetType, Long targetId);
 
     // 특정 대상의 좋아요 수
     long countByTargetTypeAndTargetId(LikeTargetType targetType, Long targetId);
 
     // 특정 사용자의 특정 대상 좋아요 삭제
-    void deleteByUserAndTargetTypeAndTargetId(User user, LikeTargetType targetType, Long targetId);
+    void deleteByUserIdAndTargetTypeAndTargetId(Long userId, LikeTargetType targetType, Long targetId);
 }

--- a/src/main/java/com/be/sportizebe/domain/like/service/LikeService.java
+++ b/src/main/java/com/be/sportizebe/domain/like/service/LikeService.java
@@ -2,15 +2,14 @@ package com.be.sportizebe.domain.like.service;
 
 import com.be.sportizebe.domain.like.dto.response.LikeResponse;
 import com.be.sportizebe.domain.like.entity.LikeTargetType;
-import com.be.sportizebe.domain.user.entity.User;
 
 public interface LikeService {
 
   // 좋아요 토글 (좋아요 추가/취소)
-  LikeResponse toggleLike(User user, LikeTargetType targetType, Long targetId);
+  LikeResponse toggleLike(Long userId, LikeTargetType targetType, Long targetId);
 
   // 좋아요 여부 확인
-  boolean isLiked(User user, LikeTargetType targetType, Long targetId);
+  boolean isLiked(Long userId, LikeTargetType targetType, Long targetId);
 
   // 좋아요 수 조회
   long getLikeCount(LikeTargetType targetType, Long targetId);

--- a/src/main/java/com/be/sportizebe/domain/post/controller/PostController.java
+++ b/src/main/java/com/be/sportizebe/domain/post/controller/PostController.java
@@ -6,14 +6,13 @@ import com.be.sportizebe.domain.post.dto.response.PostPageResponse;
 import com.be.sportizebe.domain.post.dto.response.PostResponse;
 import com.be.sportizebe.domain.post.entity.PostProperty;
 import com.be.sportizebe.domain.post.service.PostService;
-import com.be.sportizebe.domain.user.entity.User;
 import com.be.sportizebe.global.response.BaseResponse;
+import com.be.sportizebe.global.cache.dto.UserAuthInfo;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
@@ -37,9 +36,9 @@ public class PostController {
     public ResponseEntity<BaseResponse<PostResponse>> createPost(
         @Parameter(description = "게시판 종류 (SOCCER, BASKETBALL, FREE)") @PathVariable PostProperty property,
         @RequestPart("request") @Valid CreatePostRequest request,
-        @RequestPart(value = "image", required = false) MultipartFile image, // JSON 아님
-        @AuthenticationPrincipal User user) {
-        PostResponse response = postService.createPost(property, request, image, user);
+        @RequestPart(value = "image", required = false) MultipartFile image,
+        @AuthenticationPrincipal UserAuthInfo userAuthInfo) {
+        PostResponse response = postService.createPost(property, request, image, userAuthInfo.getId());
         return ResponseEntity.status(HttpStatus.CREATED)
             .body(BaseResponse.success("게시글 생성 성공", response));
     }
@@ -49,8 +48,8 @@ public class PostController {
     public ResponseEntity<BaseResponse<PostResponse>> updatePost(
         @Parameter(description = "게시글 ID") @PathVariable Long postId,
         @RequestBody @Valid UpdatePostRequest request,
-        @AuthenticationPrincipal User user) {
-        PostResponse response = postService.updatePost(postId, request, user);
+        @AuthenticationPrincipal UserAuthInfo userAuthInfo) {
+        PostResponse response = postService.updatePost(postId, request, userAuthInfo.getId());
         return ResponseEntity.ok(BaseResponse.success("게시글 수정 성공", response));
     }
 
@@ -58,8 +57,8 @@ public class PostController {
     @Operation(summary = "게시글 삭제", description = "게시글 삭제 (작성자만 가능)")
     public ResponseEntity<BaseResponse<Void>> deletePost(
         @Parameter(description = "게시글 ID") @PathVariable Long postId,
-        @AuthenticationPrincipal User user) {
-        postService.deletePost(postId, user);
+        @AuthenticationPrincipal UserAuthInfo userAuthInfo) {
+        postService.deletePost(postId, userAuthInfo.getId());
         return ResponseEntity.ok(BaseResponse.success("게시글 삭제 성공", null));
     }
 

--- a/src/main/java/com/be/sportizebe/domain/post/service/PostService.java
+++ b/src/main/java/com/be/sportizebe/domain/post/service/PostService.java
@@ -5,17 +5,15 @@ import com.be.sportizebe.domain.post.dto.request.UpdatePostRequest;
 import com.be.sportizebe.domain.post.dto.response.PostPageResponse;
 import com.be.sportizebe.domain.post.dto.response.PostResponse;
 import com.be.sportizebe.domain.post.entity.PostProperty;
-import com.be.sportizebe.domain.user.entity.User;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface PostService {
-  PostResponse createPost(PostProperty property, CreatePostRequest request, MultipartFile image, User user); // 게시글 생성
+  PostResponse createPost(PostProperty property, CreatePostRequest request, MultipartFile image, Long userId); // 게시글 생성
 
-  PostResponse updatePost(Long postId, UpdatePostRequest request, User user); // 게시글 수정
+  PostResponse updatePost(Long postId, UpdatePostRequest request, Long userId); // 게시글 수정
 
-  void deletePost(Long postId, User user); // 게시글 삭제
+  void deletePost(Long postId, Long userId); // 게시글 삭제
 
   PostPageResponse getPosts(PostProperty property, Pageable pageable); // 게시글 목록 조회
 }

--- a/src/main/java/com/be/sportizebe/domain/user/controller/UserController.java
+++ b/src/main/java/com/be/sportizebe/domain/user/controller/UserController.java
@@ -1,13 +1,11 @@
 package com.be.sportizebe.domain.user.controller;
 
-import com.be.sportizebe.domain.auth.exception.AuthErrorCode;
 import com.be.sportizebe.domain.user.dto.request.SignUpRequest;
 import com.be.sportizebe.domain.user.dto.response.ProfileImageResponse;
 import com.be.sportizebe.domain.user.dto.response.SignUpResponse;
-import com.be.sportizebe.domain.user.entity.User;
 import com.be.sportizebe.domain.user.service.UserServiceImpl;
-import com.be.sportizebe.global.exception.CustomException;
 import com.be.sportizebe.global.response.BaseResponse;
+import com.be.sportizebe.global.cache.dto.UserAuthInfo;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -38,10 +36,10 @@ public class UserController {
     @PostMapping(value = "/profile-image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "프로필 사진 업로드", description = "사용자 프로필 사진을 업로드합니다. (최대 5MB, jpg/jpeg/png/gif/webp 지원)")
     public ResponseEntity<BaseResponse<ProfileImageResponse>> uploadProfileImage(
-        @AuthenticationPrincipal User user,
+        @AuthenticationPrincipal UserAuthInfo userAuthInfo,
         @RequestPart("file") MultipartFile file
     ) {
-        ProfileImageResponse response = userService.uploadProfileImage(user.getId(), file);
+        ProfileImageResponse response = userService.uploadProfileImage(userAuthInfo.getId(), file);
         return ResponseEntity.ok(BaseResponse.success("프로필 사진 업로드 성공", response));
     }
 }

--- a/src/main/java/com/be/sportizebe/domain/user/service/UserService.java
+++ b/src/main/java/com/be/sportizebe/domain/user/service/UserService.java
@@ -12,5 +12,4 @@ public interface UserService {
 
   // 프로필 사진 업로드
   ProfileImageResponse uploadProfileImage(Long userId, MultipartFile file);
-
 }

--- a/src/main/java/com/be/sportizebe/global/cache/dto/UserAuthInfo.java
+++ b/src/main/java/com/be/sportizebe/global/cache/dto/UserAuthInfo.java
@@ -1,0 +1,32 @@
+package com.be.sportizebe.global.cache.dto;
+
+import com.be.sportizebe.domain.user.entity.Role;
+import com.be.sportizebe.domain.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+/**
+ * JWT 인증 필터에서 사용할 캐시용 사용자 정보 DTO
+ * User 엔티티의 연관관계(posts 등)로 인한 직렬화 문제를 방지
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserAuthInfo implements Serializable { // Serializable : 직렬화 가능하다라는 마커 표시
+    private Long id;
+    private String username;
+    private String nickname;
+    private Role role;
+
+    public static UserAuthInfo from(User user) {
+        return new UserAuthInfo(
+                user.getId(),
+                user.getUsername(),
+                user.getNickname(),
+                user.getRole()
+        );
+    }
+}

--- a/src/main/java/com/be/sportizebe/global/cache/service/UserCacheService.java
+++ b/src/main/java/com/be/sportizebe/global/cache/service/UserCacheService.java
@@ -1,0 +1,42 @@
+package com.be.sportizebe.global.cache.service;
+
+import com.be.sportizebe.global.cache.dto.UserAuthInfo;
+import com.be.sportizebe.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+/**
+ * JWT 인증 필터에서 사용할 사용자 정보 캐시 서비스
+ * Filter는 Spring AOP 프록시 범위 밖이므로 별도 서비스로 분리
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserCacheService {
+
+    private final UserRepository userRepository;
+
+    /**
+     * userId로 사용자 인증 정보 조회 (캐시 적용)
+     * 캐시 TTL: 5분 (RedisCacheConfig에서 설정)
+     */
+    @Cacheable(cacheNames = "userAuthInfo", key = "#userId", unless = "#result == null")
+    public UserAuthInfo findUserAuthInfoById(Long userId) {
+        log.debug("DB에서 사용자 정보 조회: userId={}", userId);
+        return userRepository.findById(userId)
+                .map(UserAuthInfo::from)
+                .orElse(null);
+    }
+
+    /**
+     * 사용자 정보 변경 시 캐시 무효화
+     * 비밀번호 변경, 역할 변경, 회원 탈퇴 등에서 호출
+     */
+    @CacheEvict(cacheNames = "userAuthInfo", key = "#userId")
+    public void evictUserAuthInfo(Long userId) {
+        log.debug("사용자 캐시 무효화: userId={}", userId);
+    }
+}

--- a/src/main/java/com/be/sportizebe/global/config/RedisCacheConfig.java
+++ b/src/main/java/com/be/sportizebe/global/config/RedisCacheConfig.java
@@ -2,6 +2,7 @@ package com.be.sportizebe.global.config;
 
 import com.be.sportizebe.domain.comment.dto.response.CommentListResponse;
 import com.be.sportizebe.domain.post.dto.response.PostPageResponse;
+import com.be.sportizebe.global.cache.dto.UserAuthInfo;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
@@ -57,6 +58,11 @@ public class RedisCacheConfig {
         Jackson2JsonRedisSerializer<Boolean> likeStatusSerializer =
                 new Jackson2JsonRedisSerializer<>(Boolean.class);
         likeStatusSerializer.setObjectMapper(objectMapper);
+
+        // userAuthInfo 캐시는 UserAuthInfo 타입으로 역직렬화
+        Jackson2JsonRedisSerializer<UserAuthInfo> userAuthInfoSerializer =
+                new Jackson2JsonRedisSerializer<>(UserAuthInfo.class);
+        userAuthInfoSerializer.setObjectMapper(objectMapper);
 
 
         // 기본 캐시 설정
@@ -115,6 +121,17 @@ public class RedisCacheConfig {
                         )
                         .entryTtl(Duration.ofSeconds(15))
         );
+
+        // JWT 인증 필터에서 사용하는 사용자 인증 정보 캐시 (TTL: 5분)
+        cacheConfigs.put(
+                "userAuthInfo",
+                RedisCacheConfiguration.defaultCacheConfig()
+                        .serializeValuesWith(
+                                RedisSerializationContext.SerializationPair.fromSerializer(userAuthInfoSerializer)
+                        )
+                        .entryTtl(Duration.ofMinutes(5))
+        );
+
         return RedisCacheManager.builder(redisConnectionFactory)
                 .cacheDefaults(defaultConfig)
                 .withInitialCacheConfigurations(cacheConfigs)


### PR DESCRIPTION
## #️⃣ Issue Number
- #31 
<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)
### 구현 요약                                                                                                                                                                                              
                                                                                                                                                                                                         
  새로 생성된 파일                                                                                                                                                                                       
  - UserAuthInfo.java :  JWT 인증용 캐시 DTO (id, username, nickname, role)                                                                                                                
  수정된 파일 
  - UserCacheServie.java : 사용자 정보 캐시 서비스 (@Cacheable 적용)                                                                                                                                                                                            
                                                                                                                                                                                                         
  캐시 설정                                                                                                                                                                                              
  - RedisCacheConfig.java - userAuthInfo 캐시 추가 (TTL: 5분)       
  - User 관련 HTTP api dto와 Caching dto를 분리 -> User관련 HTTP dto에는 민감한 정보가 있기 때문에 재사용x                                                                                                                                     
                                                                                                                                                                                                         
  인증 필터                                                                                                                                                                                              
  - JwtAuthenticationFilter.java - UserCacheService 사용으로 변경                                                                                                                                        
                                                                                                                                                                                                         
  컨트롤러 (6개)                                                                                                                                                                                         
  - @AuthenticationPrincipal User → @AuthenticationPrincipal UserAuthInfo                                                                                                                                
                                                                                                                                                                                                         
  서비스 인터페이스/구현체 (10개)                                                                                                                                                                        
  - User user 파라미터 → Long userId로 변경                                                                                                                                                              
                                                                                                                                                                                                         
  리포지토리 (2개)                                                                                                                                                                                       
  - LikeRepository, ChatRoomRepository - 메서드 시그니처 변경                                                                                                                                            
                                                                                                                                                                                                         
  ---                                                                                                                                                                                                    
  ### 캐시 효과                                                                                                                                                                                              
                                                                                                                                                                                                         
  변경 전: 인증된 API 요청마다 userRepository.findById() 호출 (DB 조회)                                                                                                                                  
                                                                                                                                                                                                         
  변경 후: Redis에서 UserAuthInfo 조회 (5분 TTL)           
  - 캐시 미스(첫요청) : Redis 조회 -> DB조회 -> Redis 저장 -> 응답
  - 캐시 히트(이후 요청(TTL만료전까지)) : Redis 조회 -> 응답                                                                                                                                              
  - DB 부하 감소                                                                                                                                                                                         
  - 응답 속도 향상 (408ms -> 11ms) : 추후 더미로 테스트 다시                      

 --- 


<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [x] 파일 혹은 폴더명 수정

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어
- 추후 사용자 정보 변경 로직 적용 필요 (캐시 무효화 로직 적용)
- 사용자 정보 변경된 경우 캐시 정보 갱신
 // UserCacheService.java
 @CacheEvict(cacheNames = "userAuthInfo", key = "#userId")
public void evictUserAuthInfo(Long userId) {
log.debug("사용자 캐시 무효화: userId={}", userId);
}

  - 사용자 정보가 변경되는 시점에서 호출!!! -> 현재 변경 로직 미구현

사용자 정보 변경되는 시점

- 닉네임 변경
- 역할(Role)변경
- 회원 탈퇴
<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **성능 개선**
  * 사용자 인증 정보 캐싱 기능을 추가하여 인증 관련 API 응답 속도 향상

* **보안 강화**
  * 인증 처리 메커니즘을 개선하여 사용자 데이터 보호 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->